### PR TITLE
Temporal encodings of the embeddings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 *.out
 *.toc
 *.synctex.gz
-conf/
+**/conf

--- a/conf/gen/dbg.yaml
+++ b/conf/gen/dbg.yaml
@@ -13,6 +13,7 @@ p: 2 # p norm in embedding space
 env: embedding_space_nodes # multicut_embedding/embedding_space
 model_name: 'agent_model'
 resume: false # resume from state dict model_name in base_dir
+embedding_dist: cosine
 
 # patch manager conf
 patch_shape: [128, 128]

--- a/conf/trainer/dbg.yaml
+++ b/conf/trainer/dbg.yaml
@@ -6,7 +6,7 @@ data_update_frequency: 10  # update env data after n steps
 post_stats_frequency: 1  # post logs after n steps
 post_model_frequency: 100  # post model param distributions after n steps
 n_updates_per_step: 10  # perform n optim steps per env step
-max_episode_length: 1  # Maximum episode length (if env is multicut_embedding this should be 1)
+max_episode_length: 10  # Maximum episode length (if env is multicut_embedding this should be 1)
 batch_size: 2  # num of images to segment
 # conf for lr scheduling
 lr_sched:

--- a/models/agent_model.py
+++ b/models/agent_model.py
@@ -16,12 +16,12 @@ class Agent(torch.nn.Module):
         self.writer_counter = 0
         self.StateClass = StateClass
 
-        self.actor = PolicyNet(self.cfg.fe.n_embedding_features+2, self.cfg.sac.n_actions * 2, cfg.model.n_hidden,
+        self.actor = PolicyNet(self.cfg.fe.n_embedding_features + 1, self.cfg.sac.n_actions * 2, cfg.model.n_hidden,
                                cfg.model.hl_factor, device, writer, "nodes" in self.cfg.gen.env)
-        self.critic = DoubleQValueNet(self.cfg.sac.s_subgraph, self.cfg.fe.n_embedding_features + 2,
+        self.critic = DoubleQValueNet(self.cfg.sac.s_subgraph, self.cfg.fe.n_embedding_features + 1,
                                       self.cfg.sac.n_actions, 1, cfg.model.n_hidden, cfg.model.hl_factor, device,
                                       writer, "nodes" in self.cfg.gen.env)
-        self.critic_tgt = DoubleQValueNet(self.cfg.sac.s_subgraph, self.cfg.fe.n_embedding_features + 2,
+        self.critic_tgt = DoubleQValueNet(self.cfg.sac.s_subgraph, self.cfg.fe.n_embedding_features + 1,
                                           self.cfg.sac.n_actions, 1, cfg.model.n_hidden, cfg.model.hl_factor, device,
                                           writer, "nodes" in self.cfg.gen.env)
 
@@ -39,8 +39,7 @@ class Agent(torch.nn.Module):
 
     def forward(self, state, actions, post_input, policy_opt, embeddings_opt, return_node_features):
         state = self.StateClass(*state)
-        round_n = state.round_n / self.cfg.trainer.max_episode_length
-        node_features = torch.cat((state.node_embeddings, state.sup_masses, torch.ones_like(state.sup_masses) * round_n), 1)
+        node_features = torch.cat((state.node_embeddings, state.sup_masses), 1)
         edge_index = torch.cat([state.edge_ids, torch.stack([state.edge_ids[1], state.edge_ids[0]], dim=0)], dim=1)  # gcnn expects two directed edges for one undirected edge
         if actions is None:
             with torch.set_grad_enabled(policy_opt):

--- a/utils/temporal_encoding.py
+++ b/utils/temporal_encoding.py
@@ -1,0 +1,37 @@
+import torch
+
+class TemporalSineEncoding(object):
+
+    def __init__(self, max_step, size):
+        """
+        uniquely encodes a time-step into sine and cosine-frequencies
+        :param max_step: maximum discrete time step
+        :param size: dim of the encoding vector
+        """
+        super(TemporalSineEncoding, self).__init__()
+        self.max_step = max_step
+        self.size = size
+
+    def __call__(self, step, device):
+        dims = torch.arange(1, self.size + 1, device=device)
+        ret = torch.zeros_like(dims).float()
+
+        ret[0::2] = torch.sin(step/(self.max_step**(dims[0::2]/self.size)))
+        ret[1::2] = torch.cos(step/(self.max_step**(dims[1::2]/self.size)))
+
+        return ret
+
+
+if __name__=="__main__":
+    import matplotlib.pyplot as plt
+    # do some tests to figure out what frequencies to use.
+    n_dim = 8
+    max_step = 10
+
+    for i in range(n_dim):
+        if i % 2 == 0:
+            plt.plot(torch.sin((torch.arange(max_step * 100) / 100) / (max_step**(i/n_dim))))
+        else:
+            plt.plot(torch.cos((torch.arange(max_step * 100) / 100) / (max_step**(i/n_dim))))
+
+    plt.show()


### PR DESCRIPTION
For the multistep update it is crucial that the current state (node feature vectors) encodes the current time-step. 
This can either be done by appending the normalized time step to each node feature vector (done this before and did not work so well).
Or the time step is encoded in a more apparent way like the positional encodings in [here](https://arxiv.org/pdf/1706.03762.pdf)
where each step is transformed to a vector containing samples of the sine function with different frequencies in each dimension. This encoding has the same size as the state and is added to the state.
